### PR TITLE
update workflow for all platforms

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ name: "publish"
 on:
   push:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   publish-tauri:
@@ -12,29 +13,32 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v2
-    - name: setup node
-      uses: actions/setup-node@v1
-      with:
-        node-version: 16
-    - name: GitHub Action for pnpm
-      # You may pin to the exact commit or the version.
-      # uses: znck/pnpm@aa6c9dc74df684c62617db39734aa897f1859f61
-      uses: znck/pnpm@v0.1.0-alpha.1
-    - name: install Rust stable
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
+    - name: Checkout repository
+      uses: actions/checkout@v4
     - name: install dependencies (ubuntu only)
       if: matrix.platform == 'ubuntu-20.04'
       run: |
         sudo apt-get update
         sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf
-    - name: install app dependencies and build it
-      run: yarn && yarn build
-    - uses: tauri-apps/tauri-action@v0
+    - name: Rust setup
+      uses: dtolnay/rust-toolchain@stable
+    - name: Rust cache
+      uses: swatinem/rust-cache@v2
+      with:
+        workspaces: './src-tauri -> target'
+    - name: Sync node version and setup cache
+      uses: actions/setup-node@v4
+      with:
+        node-version: 'lts/*'
+        cache: 'yarn' # Set this to npm, yarn or pnpm.
+    - name: Install frontend dependencies
+      # If you don't have `beforeBuildCommand` configured you may want to build your frontend here too.
+      run: yarn # Change this to npm, yarn or pnpm.
+    - name: Build the app
+      uses: tauri-apps/tauri-action@v0
+
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.TAURI_TOKEN }}
       with:
         tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version
         releaseName: "App v__VERSION__"


### PR DESCRIPTION
The result is [here](https://github.com/stormckey/stockman/releases/tag/app-v1.0.6).
Note that the token name is renamed to `TAURI_TOKEN` by me since it's not allowed to created a secret begin with `GITHUB_`, you can change it if you want.
This implementation does not take care of version control.